### PR TITLE
[NFR] Data access

### DIFF
--- a/src/Mantasflowers.Contracts/Payment/Request/PostCreateCouponRequest.cs
+++ b/src/Mantasflowers.Contracts/Payment/Request/PostCreateCouponRequest.cs
@@ -14,8 +14,8 @@ namespace Mantasflowers.Contracts.Payment.Request
 
         public DateTime RedeemBy { get; set; }
 
-        public long DiscountPrice { get; set; }
+        public decimal DiscountPrice { get; set; }
 
-        public long OrderOverPrice { get; set; }
+        public decimal OrderOverPrice { get; set; }
     }
 }

--- a/src/Mantasflowers.Contracts/Payment/Response/PostCreateCouponResponse.cs
+++ b/src/Mantasflowers.Contracts/Payment/Response/PostCreateCouponResponse.cs
@@ -20,9 +20,9 @@ namespace Mantasflowers.Contracts.Payment.Response
 
         public string Currency { get; set; }
 
-        public long DiscountPrice { get; set; }
+        public decimal DiscountPrice { get; set; }
 
-        public long OrderOverPrice { get; set; }
+        public decimal OrderOverPrice { get; set; }
 
         public long TimesRedeemed { get; set; }
     }

--- a/src/Mantasflowers.Services/DataAccess/IUnitOfWork.cs
+++ b/src/Mantasflowers.Services/DataAccess/IUnitOfWork.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Mantasflowers.Services.DataAccess.Repositories;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Mantasflowers.Services.DataAccess
+{
+    public interface IUnitOfWork
+    {
+        IProductRepository ProductRepository { get; }
+        IProductReviewRepository ProductReviewRepository { get; }
+        IUserRepository UserRepository { get; }
+
+        Task<int> SaveChangesAsync();
+
+        IExecutionStrategy CreateExecutionStrategy();
+
+        Task<IDbContextTransaction> BeginTransactionAsync();
+    }
+}

--- a/src/Mantasflowers.Services/DataAccess/IUnitOfWork.cs
+++ b/src/Mantasflowers.Services/DataAccess/IUnitOfWork.cs
@@ -9,6 +9,8 @@ namespace Mantasflowers.Services.DataAccess
         IProductRepository ProductRepository { get; }
         IProductReviewRepository ProductReviewRepository { get; }
         IUserRepository UserRepository { get; }
+        ICouponRepository CouponRepository { get; }
+        IOrderRepository OrderRepository { get; }
 
         Task<int> SaveChangesAsync();
 

--- a/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Mantasflowers.Domain.Entities;
 using Mantasflowers.Persistence;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public abstract class BaseRepository<T> : IBaseRepository<T>
         where T : BaseEntity
@@ -17,16 +17,14 @@ namespace Mantasflowers.Services.Repositories
 
         public virtual async Task<T> CreateAsync(T entity)
         {
-            var entityEntry = _dbContext.Add(entity);
-            await _dbContext.SaveChangesAsync();
+            var entityEntry = await _dbContext.AddAsync(entity);
 
             return entityEntry.Entity;
         }
 
-        public virtual async Task DeleteAsync(T entity)
+        public virtual void Delete(T entity)
         {
-            var result = _dbContext.Remove(entity);
-            await _dbContext.SaveChangesAsync();
+            _dbContext.Remove(entity);
         }
 
         public virtual async Task<T> GetAsync(Guid id)
@@ -34,12 +32,16 @@ namespace Mantasflowers.Services.Repositories
             return await _dbContext.FindAsync<T>(id);
         }
 
-        public virtual async Task<T> UpdateAsync(T entity)
+        public virtual T UpdateAsync(T entity)
         {
             var entityEntry = _dbContext.Update(entity);
-            await _dbContext.SaveChangesAsync();
 
             return entityEntry.Entity;
+        }
+
+        public virtual async Task<int> SaveChangesAsync()
+        {
+            return await _dbContext.SaveChangesAsync();
         }
     }
 }

--- a/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Mantasflowers.Domain.Entities;
 using Mantasflowers.Persistence;
-using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Mantasflowers.Services.DataAccess.Repositories
 {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/BaseRepository.cs
@@ -32,7 +32,7 @@ namespace Mantasflowers.Services.DataAccess.Repositories
             return await _dbContext.FindAsync<T>(id);
         }
 
-        public virtual T UpdateAsync(T entity)
+        public virtual T Update(T entity)
         {
             var entityEntry = _dbContext.Update(entity);
 

--- a/src/Mantasflowers.Services/DataAccess/Repositories/CouponRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/CouponRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Mantasflowers.Domain.Entities;
 using Mantasflowers.Persistence;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public class CouponRepository : BaseRepository<Coupon>, ICouponRepository
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
@@ -11,7 +11,7 @@ namespace Mantasflowers.Services.DataAccess.Repositories
 
         Task<T> GetAsync(Guid id);
 
-        T UpdateAsync(T entity);
+        T Update(T entity);
 
         void Delete(T entity);
 

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Mantasflowers.Domain.Entities;
-using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Mantasflowers.Services.DataAccess.Repositories
 {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IBaseRepository.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Mantasflowers.Domain.Entities;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface IBaseRepository<T>
         where T : BaseEntity
@@ -11,8 +11,10 @@ namespace Mantasflowers.Services.Repositories
 
         Task<T> GetAsync(Guid id);
 
-        Task<T> UpdateAsync(T entity);
+        T UpdateAsync(T entity);
 
-        Task DeleteAsync(T entity);
+        void Delete(T entity);
+
+        Task<int> SaveChangesAsync();
     }
 }

--- a/src/Mantasflowers.Services/DataAccess/Repositories/ICouponRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/ICouponRepository.cs
@@ -1,6 +1,6 @@
 ﻿using Mantasflowers.Domain.Entities;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface ICouponRepository : IBaseRepository<Coupon>
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IOrderRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IOrderRepository.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface IOrderRepository : IBaseRepository<Order>
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IProductRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IProductRepository.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Mantasflowers.Contracts.Common;
 using Mantasflowers.Domain.Entities;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface IProductRepository : IBaseRepository<Product>
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IProductReviewRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IProductReviewRepository.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Mantasflowers.Domain.Entities;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface IProductReviewRepository : IBaseRepository<ProductReview>
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/IUserRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/IUserRepository.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public interface IUserRepository : IBaseRepository<User>
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/OrderRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/OrderRepository.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Threading.Tasks;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public class OrderRepository : BaseRepository<Order>, IOrderRepository
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/ProductRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/ProductRepository.cs
@@ -8,7 +8,7 @@ using Mantasflowers.Persistence;
 using Mantasflowers.Services.DataShaping;
 using Microsoft.EntityFrameworkCore;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public class ProductRepository : BaseRepository<Product>, IProductRepository
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/ProductReviewRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/ProductReviewRepository.cs
@@ -5,7 +5,7 @@ using Mantasflowers.Domain.Entities;
 using Mantasflowers.Persistence;
 using Microsoft.EntityFrameworkCore;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public class ProductReviewRepository : BaseRepository<ProductReview>, IProductReviewRepository
     {
@@ -49,8 +49,7 @@ namespace Mantasflowers.Services.Repositories
                 ReviewScore = score,
             };
 
-            await _dbContext.ProductReviews.AddAsync(review);
-            await _dbContext.SaveChangesAsync();
+            await CreateAsync(review);
         }
     }   
 }

--- a/src/Mantasflowers.Services/DataAccess/Repositories/UserRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/UserRepository.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Mantasflowers.Services.Repositories
+namespace Mantasflowers.Services.DataAccess.Repositories
 {
     public class UserRepository : BaseRepository<User>, IUserRepository
     {

--- a/src/Mantasflowers.Services/DataAccess/Repositories/UserRepository.cs
+++ b/src/Mantasflowers.Services/DataAccess/Repositories/UserRepository.cs
@@ -2,7 +2,6 @@
 using Mantasflowers.Persistence;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Mantasflowers.Services.DataAccess.Repositories

--- a/src/Mantasflowers.Services/DataAccess/UnitOfWork.cs
+++ b/src/Mantasflowers.Services/DataAccess/UnitOfWork.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using Mantasflowers.Persistence;
+using Mantasflowers.Services.DataAccess.Repositories;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Mantasflowers.Services.DataAccess
+{
+    public class UnitOfWork : IUnitOfWork
+    {
+        private readonly DatabaseContext _dbContext;
+        private readonly IProductRepository _productRepository;
+        private readonly IProductReviewRepository _productReviewRepository;
+        private readonly IUserRepository _userReviewRepository;
+
+        public UnitOfWork(
+            DatabaseContext dbContext,
+            IProductRepository productRepository,
+            IProductReviewRepository productReviewRepository,
+            IUserRepository userReviewRepository)
+        {
+            _dbContext = dbContext;
+            _productRepository = productRepository;
+            _productReviewRepository = productReviewRepository;
+            _userReviewRepository = userReviewRepository;
+        }
+
+
+        public IProductRepository ProductRepository
+            => _productRepository;
+
+        public IProductReviewRepository ProductReviewRepository
+            => _productReviewRepository;
+
+        public IUserRepository UserRepository
+            => _userReviewRepository;
+
+
+        public async Task<int> SaveChangesAsync()
+        {
+            return await _dbContext.SaveChangesAsync();
+        }
+
+        public IExecutionStrategy CreateExecutionStrategy()
+        {
+            return _dbContext.Database.CreateExecutionStrategy();
+        }
+
+        public async Task<IDbContextTransaction> BeginTransactionAsync()
+        {
+            return await _dbContext.Database.BeginTransactionAsync();
+        }
+    }
+}

--- a/src/Mantasflowers.Services/DataAccess/UnitOfWork.cs
+++ b/src/Mantasflowers.Services/DataAccess/UnitOfWork.cs
@@ -11,17 +11,24 @@ namespace Mantasflowers.Services.DataAccess
         private readonly IProductRepository _productRepository;
         private readonly IProductReviewRepository _productReviewRepository;
         private readonly IUserRepository _userReviewRepository;
+        private readonly ICouponRepository _couponRepository;
+        private readonly IOrderRepository _orderRepository;
 
         public UnitOfWork(
             DatabaseContext dbContext,
             IProductRepository productRepository,
             IProductReviewRepository productReviewRepository,
-            IUserRepository userReviewRepository)
+            IUserRepository userReviewRepository,
+            ICouponRepository couponRepository,
+            IOrderRepository orderRepository
+            )
         {
             _dbContext = dbContext;
             _productRepository = productRepository;
             _productReviewRepository = productReviewRepository;
             _userReviewRepository = userReviewRepository;
+            _couponRepository = couponRepository;
+            _orderRepository = orderRepository;
         }
 
 
@@ -33,6 +40,12 @@ namespace Mantasflowers.Services.DataAccess
 
         public IUserRepository UserRepository
             => _userReviewRepository;
+
+        public ICouponRepository CouponRepository
+            => _couponRepository;
+
+        public IOrderRepository OrderRepository
+            => _orderRepository;
 
 
         public async Task<int> SaveChangesAsync()

--- a/src/Mantasflowers.Services/Mapping/ProductMappings.cs
+++ b/src/Mantasflowers.Services/Mapping/ProductMappings.cs
@@ -6,8 +6,8 @@ namespace Mantasflowers.Services.Mapping
 {
     public static class ProductMappings
     {
-        public static readonly Dictionary<ProductOrderByOptions?, string> ProductSortingMapping
-            = new Dictionary<ProductOrderByOptions?, string>
+        public static readonly Dictionary<ProductOrderByOptions, string> ProductSortingMapping
+            = new Dictionary<ProductOrderByOptions, string>
             {
                 { ProductOrderByOptions.NAME, nameof(Product.Name) },
                 { ProductOrderByOptions.PRICE, nameof(Product.Price) },

--- a/src/Mantasflowers.Services/Mapping/ProductMappings.cs
+++ b/src/Mantasflowers.Services/Mapping/ProductMappings.cs
@@ -7,7 +7,7 @@ namespace Mantasflowers.Services.Mapping
     public static class ProductMappings
     {
         public static readonly Dictionary<ProductOrderByOptions, string> ProductSortingMapping
-            = new Dictionary<ProductOrderByOptions, string>
+            = new()
             {
                 { ProductOrderByOptions.NAME, nameof(Product.Name) },
                 { ProductOrderByOptions.PRICE, nameof(Product.Price) },

--- a/src/Mantasflowers.Services/Services/Coupon/CouponService.cs
+++ b/src/Mantasflowers.Services/Services/Coupon/CouponService.cs
@@ -1,21 +1,20 @@
 ﻿using AutoMapper;
 using Mantasflowers.Contracts.Payment.Request;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using System.Threading.Tasks;
 
 namespace Mantasflowers.Services.Services.Coupon
 {
     public class CouponService : ICouponService
     {
-        private readonly ICouponRepository _couponRepository;
+        private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
-        public CouponService(ICouponRepository couponRepository, IMapper mapper)
+        public CouponService(IUnitOfWork unitOfWork, IMapper mapper)
         {
-            _couponRepository = couponRepository;
+            _unitOfWork = unitOfWork;
             _mapper = mapper;
         }
 
@@ -25,7 +24,7 @@ namespace Mantasflowers.Services.Services.Coupon
 
             try
             {
-                coupon = await _couponRepository.CreateAsync(coupon);
+                coupon = await _unitOfWork.CouponRepository.CreateAsync(coupon);
             }
             catch (DbUpdateException)
             {
@@ -33,16 +32,6 @@ namespace Mantasflowers.Services.Services.Coupon
             }
 
             return coupon;
-        }
-
-        public Task<IDbContextTransaction> BeginTransactionAsync()
-        {
-            return _couponRepository.BeginTransactionAsync();
-        }
-
-        public IExecutionStrategy CreateExecutionStrategy()
-        {
-            return _couponRepository.CreateExecutionStrategy();
         }
     }
 }

--- a/src/Mantasflowers.Services/Services/Coupon/ICouponService.cs
+++ b/src/Mantasflowers.Services/Services/Coupon/ICouponService.cs
@@ -1,5 +1,4 @@
 ﻿using Mantasflowers.Contracts.Payment.Request;
-using Microsoft.EntityFrameworkCore.Storage;
 using System.Threading.Tasks;
 
 namespace Mantasflowers.Services.Services.Coupon
@@ -7,9 +6,5 @@ namespace Mantasflowers.Services.Services.Coupon
     public interface ICouponService
     {
         Task<Domain.Entities.Coupon> CreateCouponAsync(PostCreateCouponRequest request);
-
-        Task<IDbContextTransaction> BeginTransactionAsync();
-
-        IExecutionStrategy CreateExecutionStrategy();
     }
 }

--- a/src/Mantasflowers.Services/Services/Order/IOrderService.cs
+++ b/src/Mantasflowers.Services/Services/Order/IOrderService.cs
@@ -1,6 +1,5 @@
 ﻿using Mantasflowers.Contracts.Order.Request;
 using Mantasflowers.Contracts.Order.Response;
-using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Threading.Tasks;
 
@@ -13,9 +12,5 @@ namespace Mantasflowers.Services.Services.Order
         Task<GetDetailedOrderResponse> GetDetailedOrderInfoAsync(Guid id);
 
         Task<Domain.Entities.Order> CreateOrderAsync(PostCreateOrderRequest request);
-
-        Task<IDbContextTransaction> BeginTransactionAsync();
-
-        IExecutionStrategy CreateExecutionStrategy();
     }
 }

--- a/src/Mantasflowers.Services/Services/Order/OrderService.cs
+++ b/src/Mantasflowers.Services/Services/Order/OrderService.cs
@@ -1,10 +1,9 @@
 ﻿using AutoMapper;
 using Mantasflowers.Contracts.Order.Request;
 using Mantasflowers.Contracts.Order.Response;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Threading.Tasks;
 
@@ -12,12 +11,12 @@ namespace Mantasflowers.Services.Services.Order
 {
     public class OrderService : IOrderService
     {
-        private readonly IOrderRepository _orderRepository;
+        private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
-        public OrderService(IOrderRepository orderRepository, IMapper mapper)
+        public OrderService(IUnitOfWork unitOfWork, IMapper mapper)
         {
-            _orderRepository = orderRepository;
+            _unitOfWork = unitOfWork;
             _mapper = mapper;
         }
 
@@ -28,7 +27,7 @@ namespace Mantasflowers.Services.Services.Order
 
             try
             {
-                order = await _orderRepository.CreateAsync(order);
+                order = await _unitOfWork.OrderRepository.CreateAsync(order);
             }
             catch (DbUpdateException)
             {
@@ -40,28 +39,18 @@ namespace Mantasflowers.Services.Services.Order
 
         public async Task<Domain.Entities.Order> GetDetailedOrderAsync(Guid id)
         {
-            var order = await _orderRepository.GetDetailedOrderAsync(id);
+            var order = await _unitOfWork.OrderRepository.GetDetailedOrderAsync(id);
 
             return order;
         }
 
         public async Task<GetDetailedOrderResponse> GetDetailedOrderInfoAsync(Guid id)
         {
-            var order = await _orderRepository.GetDetailedOrderAsync(id);
+            var order = await _unitOfWork.OrderRepository.GetDetailedOrderAsync(id);
 
             var detailedOrderResponse = _mapper.Map<GetDetailedOrderResponse>(order);
 
             return detailedOrderResponse;
-        }
-
-        public Task<IDbContextTransaction> BeginTransactionAsync()
-        {
-            return _orderRepository.BeginTransactionAsync();
-        }
-
-        public IExecutionStrategy CreateExecutionStrategy()
-        {
-            return _orderRepository.CreateExecutionStrategy();
         }
     }
 }

--- a/src/Mantasflowers.Services/Services/Payment/PaymentService.cs
+++ b/src/Mantasflowers.Services/Services/Payment/PaymentService.cs
@@ -140,7 +140,7 @@ namespace Mantasflowers.Services.Services.Payment
                 {
                     Id = coupon.Id.ToString(),
                     Name = coupon.Name,
-                    AmountOff = (long)coupon.DiscountPrice * 100,
+                    AmountOff = (long)(coupon.DiscountPrice * 100),
                     Currency = "eur",
                     Duration = "repeating",
                     DurationInMonths = request.DurationInMonths,
@@ -156,15 +156,13 @@ namespace Mantasflowers.Services.Services.Payment
                     Code = coupon.Name,
                     Restrictions = new PromotionCodeRestrictionsOptions()
                     {
-                        MinimumAmount = (long)coupon.OrderOverPrice * 100,
+                        MinimumAmount = (long)(coupon.OrderOverPrice * 100),
                         MinimumAmountCurrency = "eur"
                     }
                 };
 
                 promotionCode = await _promotionCodeService.CreateAsync(promoCodeOptions);
                 promotionCode.Created = promotionCode.Created.Date;
-                promotionCode.Restrictions.MinimumAmount /= 100;
-                promotionCode.Coupon.AmountOff /= 100;
 
                 await transaction.CommitAsync();
             }

--- a/src/Mantasflowers.Services/Services/Product/ProductService.cs
+++ b/src/Mantasflowers.Services/Services/Product/ProductService.cs
@@ -5,7 +5,7 @@ using AutoMapper;
 using Mantasflowers.Contracts.Product.Request;
 using Mantasflowers.Contracts.Product.Response;
 using Mantasflowers.Services.Mapping;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess.Repositories;
 using static Mantasflowers.Services.Mapping.ProductMappings;
 
 namespace Mantasflowers.Services.Services.Product

--- a/src/Mantasflowers.Services/Services/Product/ProductService.cs
+++ b/src/Mantasflowers.Services/Services/Product/ProductService.cs
@@ -5,19 +5,19 @@ using AutoMapper;
 using Mantasflowers.Contracts.Product.Request;
 using Mantasflowers.Contracts.Product.Response;
 using Mantasflowers.Services.Mapping;
-using Mantasflowers.Services.DataAccess.Repositories;
+using Mantasflowers.Services.DataAccess;
 using static Mantasflowers.Services.Mapping.ProductMappings;
 
 namespace Mantasflowers.Services.Services.Product
 {
     public class ProductService : IProductService
     {
-        private readonly IProductRepository _productRepository;
+        private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
-        public ProductService(IProductRepository productRepository, IMapper mapper)
+        public ProductService(IUnitOfWork unitOfWork, IMapper mapper)
         {
-            _productRepository = productRepository;
+            _unitOfWork = unitOfWork;
             _mapper = mapper;
         }
 
@@ -31,7 +31,7 @@ namespace Mantasflowers.Services.Services.Product
                 throw new MappingException($"No entity property mapping found for '{nameof(request.OrderBy)}'");
             }
 
-            var paginatedProducts = await _productRepository.GetPaginatedFilteredOrderedListAsync(request.Page,
+            var paginatedProducts = await _unitOfWork.ProductRepository.GetPaginatedFilteredOrderedListAsync(request.Page,
                 request.PageSize,
                 categoryFilter,
                 orderByPropertyName,
@@ -49,7 +49,7 @@ namespace Mantasflowers.Services.Services.Product
 
         public async Task<GetDetailedProductResponse> GetDetailedProductInfoAsync(Guid id)
         {
-            var product = await _productRepository.GetDetailedProductAsync(id);
+            var product = await _unitOfWork.ProductRepository.GetDetailedProductAsync(id);
 
             var detailedProductResponse = _mapper.Map<GetDetailedProductResponse>(product);
 

--- a/src/Mantasflowers.Services/Services/Review/ProductReviewService.cs
+++ b/src/Mantasflowers.Services/Services/Review/ProductReviewService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using AutoMapper;
 using Mantasflowers.Contracts.Review.Response;
-using Mantasflowers.Services.DataAccess.Repositories;
+using Mantasflowers.Services.DataAccess;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,18 +10,18 @@ namespace Mantasflowers.Services.Services.Review
 {
     public class ProductReviewService : IProductReviewService
     {
-        private readonly IProductReviewRepository _reviewRepository;
+        private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
-        public ProductReviewService(IProductReviewRepository reviewRepository, IMapper mapper)
+        public ProductReviewService(IUnitOfWork unitOfWork, IMapper mapper)
         {
-            _reviewRepository = reviewRepository;
+            _unitOfWork = unitOfWork;
             _mapper = mapper;
         }
 
         public async Task<GetProductReviewResponse> GetProductReviewsAsync(Guid productId)
         {
-            var aggregate = await _reviewRepository.GetReviewsAggregateForProductAsync(productId);
+            var aggregate = await _unitOfWork.ProductReviewRepository.GetReviewsAggregateForProductAsync(productId);
 
             if (aggregate == null)
             {
@@ -39,19 +39,19 @@ namespace Mantasflowers.Services.Services.Review
 
         public async Task<GetProductReviewForUserResponse> GetProductReviewForUserAsync(Guid userId, Guid productId)
         {
-            var review = await _reviewRepository.GetReviewForUserAsync(userId, productId);
+            var review = await _unitOfWork.ProductReviewRepository.GetReviewForUserAsync(userId, productId);
             var response = _mapper.Map<GetProductReviewForUserResponse>(review);
 
             return response;
         }
 
-        // TODO: [NFR] transactions? Exception catching? (review could exist or concurrent create review requests)
+        // TODO: Check if user bought this item; ensure concurrent edit (edit should be separate PUT/PATCH)
         public async Task CreateReviewForUserAsync(Guid userId, Guid productId, double score)
         {
             try
             {
-                await _reviewRepository.CreateReviewForUserAsync(userId, productId, score);
-                await _reviewRepository.SaveChangesAsync();
+                await _unitOfWork.ProductReviewRepository.CreateReviewForUserAsync(userId, productId, score);
+                await _unitOfWork.SaveChangesAsync();
             }
             catch (DbUpdateException)
             {

--- a/src/Mantasflowers.Services/Services/Review/ProductReviewService.cs
+++ b/src/Mantasflowers.Services/Services/Review/ProductReviewService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using AutoMapper;
 using Mantasflowers.Contracts.Review.Response;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess.Repositories;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
@@ -51,6 +51,7 @@ namespace Mantasflowers.Services.Services.Review
             try
             {
                 await _reviewRepository.CreateReviewForUserAsync(userId, productId, score);
+                await _reviewRepository.SaveChangesAsync();
             }
             catch (DbUpdateException)
             {

--- a/src/Mantasflowers.Services/Services/User/UserService.cs
+++ b/src/Mantasflowers.Services/Services/User/UserService.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using Mantasflowers.Contracts.User.Response;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess.Repositories;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
 using System;

--- a/src/Mantasflowers.Services/Services/User/UserService.cs
+++ b/src/Mantasflowers.Services/Services/User/UserService.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using Mantasflowers.Contracts.User.Response;
-using Mantasflowers.Services.DataAccess.Repositories;
+using Mantasflowers.Services.DataAccess;
 using Mantasflowers.Services.Services.Exceptions;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -11,21 +11,21 @@ namespace Mantasflowers.Services.Services.User
     public class UserService : IUserService
     {
         private readonly FirebaseService.FirebaseService _fbService;
-        private readonly IUserRepository _userRepository;
+        private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
         public UserService(FirebaseService.FirebaseService fbService,
-            IUserRepository userRepository,
+            IUnitOfWork unitOfWork,
             IMapper mapper)
         {
-            _userRepository = userRepository;
+            _unitOfWork = unitOfWork;
             _mapper = mapper;
             _fbService = fbService;
         }
 
         public async Task<GetUserResponse> GetUserByUidAsync(string uid)
         {
-            var user = await _userRepository.GetUserByUidAsync(uid);
+            var user = await _unitOfWork.UserRepository.GetUserByUidAsync(uid);
             if (user == null)
             {
                 throw new FirebaseUidNotFoundException($"No user could be found for {nameof(uid)}");
@@ -40,7 +40,7 @@ namespace Mantasflowers.Services.Services.User
             string loginEmail,
             bool isLoginEmailVerified)
         {
-            var user = await _userRepository.GetDetailedUserByUidAsync(uid);
+            var user = await _unitOfWork.UserRepository.GetDetailedUserByUidAsync(uid);
             if (user == null)
             {
                 throw new FirebaseUidNotFoundException($"No user could be found for {nameof(uid)}");
@@ -58,7 +58,7 @@ namespace Mantasflowers.Services.Services.User
 
         public async Task<GetDetailedUserResponse> GetDetailedUserByGuidAsync(Guid id)
         {
-            var user = await _userRepository.GetDetailedUserByIdAsync(id);
+            var user = await _unitOfWork.UserRepository.GetDetailedUserByIdAsync(id);
             if (user == null)
             {
                 throw new UserNotFoundException($"No user could be found for {nameof(id)}");
@@ -78,12 +78,11 @@ namespace Mantasflowers.Services.Services.User
 
         public async Task<string> GetUserUidByGuidAsync(Guid id)
         {
-            var user = await _userRepository.GetAsync(id);
+            var user = await _unitOfWork.UserRepository.GetAsync(id);
 
             return user?.Uid;
         }
 
-        // TODO: [NFR] transactions? Exception catching? (Uid could exist or concurrent add user requests)
         public async Task<PostCreateUserResponse> CreateUserAsync(string uid)
         {
             var user = new Domain.Entities.User
@@ -93,7 +92,8 @@ namespace Mantasflowers.Services.Services.User
 
             try
             {
-                await _userRepository.CreateAsync(user);
+                await _unitOfWork.UserRepository.CreateAsync(user);
+                await _unitOfWork.SaveChangesAsync();
             }
             catch (DbUpdateException)
             {

--- a/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
+++ b/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
@@ -1,5 +1,6 @@
 using Autofac;
 using Autofac.Extras.DynamicProxy;
+using Mantasflowers.Services.DataAccess;
 using Mantasflowers.Services.DataAccess.Repositories;
 using Mantasflowers.WebApi.Setup.DI.Interceptors;
 
@@ -9,6 +10,10 @@ namespace Mantasflowers.WebApi.Setup.DI
     {
         protected override void Load(ContainerBuilder builder)
         {
+            builder.RegisterType<UnitOfWork>()
+                .As<IUnitOfWork>()
+                .InstancePerLifetimeScope();
+
             builder.RegisterType<ProductRepository>()
                 .As<IProductRepository>()
                 .EnableInterfaceInterceptors()

--- a/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
+++ b/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
@@ -13,19 +13,19 @@ namespace Mantasflowers.WebApi.Setup.DI
                 .As<IProductRepository>()
                 .EnableInterfaceInterceptors()
                 .InterceptedBy(typeof(AsyncInterceptorAdapter<MethodCallInterceptorAsync>))
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             builder.RegisterType<ProductReviewRepository>()
                 .As<IProductReviewRepository>()
                 .EnableInterfaceInterceptors()
                 .InterceptedBy(typeof(AsyncInterceptorAdapter<MethodCallInterceptorAsync>))
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             builder.RegisterType<UserRepository>()
                 .As<IUserRepository>()
                 .EnableInterfaceInterceptors()
                 .InterceptedBy(typeof(AsyncInterceptorAdapter<MethodCallInterceptorAsync>))
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             base.Load(builder);
         }

--- a/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
+++ b/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
@@ -36,13 +36,13 @@ namespace Mantasflowers.WebApi.Setup.DI
                 .As<IOrderRepository>()
                 .EnableInterfaceInterceptors()
                 .InterceptedBy(typeof(AsyncInterceptorAdapter<MethodCallInterceptorAsync>))
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             builder.RegisterType<CouponRepository>()
                 .As<ICouponRepository>()
                 .EnableInterfaceInterceptors()
                 .InterceptedBy(typeof(AsyncInterceptorAdapter<MethodCallInterceptorAsync>))
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             base.Load(builder);
         }

--- a/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
+++ b/src/Mantasflowers.WebApi/Setup/DI/RepositoriesModule.cs
@@ -1,6 +1,6 @@
 using Autofac;
 using Autofac.Extras.DynamicProxy;
-using Mantasflowers.Services.Repositories;
+using Mantasflowers.Services.DataAccess.Repositories;
 using Mantasflowers.WebApi.Setup.DI.Interceptors;
 
 namespace Mantasflowers.WebApi.Setup.DI

--- a/src/Mantasflowers.WebApi/Setup/Database/DatabaseSetup.cs
+++ b/src/Mantasflowers.WebApi/Setup/Database/DatabaseSetup.cs
@@ -27,7 +27,7 @@ namespace Mantasflowers.WebApi.Setup.Database
                         .ConfigureWarnings(x => 
                             x.Throw(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning));
                 },
-                ServiceLifetime.Transient,
+                ServiceLifetime.Scoped,
                 ServiceLifetime.Singleton);
             }
             else
@@ -38,7 +38,7 @@ namespace Mantasflowers.WebApi.Setup.Database
                         .ConfigureWarnings(x =>
                             x.Throw(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning));
                 },
-                ServiceLifetime.Transient,
+                ServiceLifetime.Scoped,
                 ServiceLifetime.Singleton);
             }
         }

--- a/src/Mantasflowers.WebApi/Setup/Mapping/PaymentProfile.cs
+++ b/src/Mantasflowers.WebApi/Setup/Mapping/PaymentProfile.cs
@@ -21,8 +21,8 @@ namespace Mantasflowers.WebApi.Setup.Mapping
                 .ForMember(d => d.Duration, opt => opt.MapFrom(d => d.Coupon.Duration))
                 .ForMember(d => d.Currency, opt => opt.MapFrom(d => d.Coupon.Currency))
                 .ForMember(d => d.Name, opt => opt.MapFrom(d => d.Code))
-                .ForMember(d => d.DiscountPrice, opt => opt.MapFrom(d => d.Coupon.AmountOff))
-                .ForMember(d => d.OrderOverPrice, opt => opt.MapFrom(d => d.Restrictions.MinimumAmount));
+                .ForMember(d => d.DiscountPrice, opt => opt.MapFrom(d => d.Coupon.AmountOff / 100m))
+                .ForMember(d => d.OrderOverPrice, opt => opt.MapFrom(d => d.Restrictions.MinimumAmount / 100m));
         }
     }
 }

--- a/src/Mantasflowers.WebApi/Startup.cs
+++ b/src/Mantasflowers.WebApi/Startup.cs
@@ -17,12 +17,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Serilog;
 
 namespace Mantasflowers.WebApi
 {

--- a/src/Mantasflowers.WebApi/Validation/Payment/PostCreateCouponRequestValidator.cs
+++ b/src/Mantasflowers.WebApi/Validation/Payment/PostCreateCouponRequestValidator.cs
@@ -10,7 +10,8 @@ namespace Mantasflowers.WebApi.Validation.Payment
         {
             RuleFor(x => x.DiscountPrice)
                 .NotEmpty()
-                .GreaterThan(0);
+                .GreaterThan(0)
+                .ScalePrecision(2, 18);
 
             RuleFor(x => x.DurationInMonths)
                 .NotEmpty()
@@ -21,7 +22,8 @@ namespace Mantasflowers.WebApi.Validation.Payment
 
             RuleFor(x => x.OrderOverPrice)
                 .NotEmpty()
-                .GreaterThanOrEqualTo(x => x.DiscountPrice);
+                .GreaterThanOrEqualTo(x => x.DiscountPrice)
+                .ScalePrecision(2, 18);
 
             RuleFor(x => x.RedeemBy)
                 .NotEmpty()

--- a/src/Mantasflowers.WebApi/Validation/ValidateRequestAttribute.cs
+++ b/src/Mantasflowers.WebApi/Validation/ValidateRequestAttribute.cs
@@ -1,4 +1,3 @@
-
 using System.Linq;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc.Filters;


### PR DESCRIPTION
Implementing some sort of  `UnitOfWork` pattern version (couldn't find a definitive solution that would solve all problems, but at least this one ensures dependency inversion). Other notes:
* Removed any `SaveChanges()` from repositories. Roundtrip to DB should be explicit.
* `dbContext` and repositories now have scoped lifetime.
* `UnitOfWork` now exposes explicit execution strategy and transaction handling (@alwaysintune no need to duplicate that code around services anymore).
* We should inject and use `UnitOfWork` instead of repositories everywhere to ensure this NFR.