### PR TITLE
Call SaveChangesAsync after CreateAsync

### DIFF
--- a/src/Mantasflowers.Services/Services/Coupon/CouponService.cs
+++ b/src/Mantasflowers.Services/Services/Coupon/CouponService.cs
@@ -25,6 +25,7 @@ namespace Mantasflowers.Services.Services.Coupon
             try
             {
                 coupon = await _unitOfWork.CouponRepository.CreateAsync(coupon);
+                await _unitOfWork.SaveChangesAsync();
             }
             catch (DbUpdateException)
             {

--- a/src/Mantasflowers.Services/Services/Order/OrderService.cs
+++ b/src/Mantasflowers.Services/Services/Order/OrderService.cs
@@ -28,6 +28,7 @@ namespace Mantasflowers.Services.Services.Order
             try
             {
                 order = await _unitOfWork.OrderRepository.CreateAsync(order);
+                await _unitOfWork.SaveChangesAsync();
             }
             catch (DbUpdateException)
             {


### PR DESCRIPTION
`CreateAsync()` no longer calls DB immediately.